### PR TITLE
Need to wait for the DB to settle on startup

### DIFF
--- a/compose.yml.example
+++ b/compose.yml.example
@@ -9,6 +9,10 @@ services:
       - bookhaven-net
     volumes:
       - /path/to/mysql/storage:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
 
   redis:
     container_name: redis
@@ -30,7 +34,8 @@ services:
     networks:
       - bookhaven-net
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
 
 networks:
   bookhaven-net:


### PR DESCRIPTION
Just a simple PR implementing the changes discussed in #4. When starting up the application (at least for the first time) via Docker, the stack needs to wait for the database to be initialized. Currently, database migrations attempt to run before the database is ready to accept connections.